### PR TITLE
OnDisconnect Function

### DIFF
--- a/concert/app/src/functions/on_disconnect/index.py
+++ b/concert/app/src/functions/on_disconnect/index.py
@@ -16,8 +16,7 @@ client_lambda = boto3.client("lambda")
 client_sns = boto3.client("sns")
 client_sqs = boto3.client("sqs")
 
-dynamodb = boto3.resource("dynamodb")
-table = dynamodb.Table(DYNAMODB_TABLE_NAME)
+table = boto3.resource("dynamodb").Table(DYNAMODB_TABLE_NAME)
 
 
 def handler(event, context):
@@ -29,7 +28,7 @@ def handler(event, context):
 
     resources = table.get_item(Key=connection_key)["Item"]
 
-    for subscription_arn in resources[ATTR_CONNECTION_SNS_SUBSCRIPTION_ARNS]:
+    for subscription_arn in sorted(resources[ATTR_CONNECTION_SNS_SUBSCRIPTION_ARNS]):
         client_sns.unsubscribe(SubscriptionArn=subscription_arn)
     client_sqs.delete_queue(QueueUrl=resources[ATTR_CONNECTION_SQS_QUEUE_URL])
 

--- a/concert/app/test/on_connect/test_on_connect.py
+++ b/concert/app/test/on_connect/test_on_connect.py
@@ -2,7 +2,6 @@ import json
 import os
 import pytest
 from boto3.dynamodb.conditions import Attr
-from botocore.exceptions import ClientError
 from botocore.stub import ANY, Stubber
 from src.functions.on_connect.index import (
     handler,

--- a/concert/app/test/on_disconnect/__init__.py
+++ b/concert/app/test/on_disconnect/__init__.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ["DYNAMODB_TABLE_NAME"] = "test-enchanted-brain"

--- a/concert/app/test/on_disconnect/test_on_disconnect.py
+++ b/concert/app/test/on_disconnect/test_on_disconnect.py
@@ -1,0 +1,118 @@
+import json
+import os
+import pytest
+from botocore.stub import Stubber
+from src.functions.on_disconnect.index import (
+    handler,
+    client_lambda,
+    client_sns,
+    client_sqs,
+    table,
+)
+
+DYNAMODB_TABLE_NAME = os.environ.get("DYNAMODB_TABLE_NAME")
+
+
+@pytest.fixture
+def get_event():
+    def _get_event(connection_id="test-connection="):
+        return {"requestContext": {"connectionId": connection_id}}
+
+    return _get_event
+
+
+def run_handler(
+    event,
+    get_item_params=None,
+    delete_item_params=None,
+    lambda_mapping_uuid="mapping-uuid",
+    lambda_params=None,
+    sns_params=None,
+    sns_subscription_arns=["subscription-arn"],
+    sqs_params=None,
+    sqs_queue_url="https://test.com/queue",
+):
+    get_item_response = {
+        "Item": {
+            "lambdaMappingUuid": {"S": lambda_mapping_uuid},
+            "snsSubscriptionArns": {"SS": sns_subscription_arns},
+            "sqsQueueUrl": {"S": sqs_queue_url},
+        }
+    }
+    stubber_dynamodb = Stubber(table.meta.client)
+    stubber_dynamodb.add_response("get_item", get_item_response, get_item_params)
+    stubber_dynamodb.add_response("delete_item", {}, delete_item_params)
+
+    stubber_sns = Stubber(client_sns)
+    for param in sns_params or sns_subscription_arns:
+        if sns_params is None:
+            param = {"SubscriptionArn": param}
+        stubber_sns.add_response("unsubscribe", {}, param)
+
+    stubber_sqs = Stubber(client_sqs)
+    stubber_sqs.add_response("delete_queue", {}, sqs_params)
+
+    stubber_lambda = Stubber(client_lambda)
+    stubber_lambda.add_response("delete_event_source_mapping", {}, lambda_params)
+
+    with stubber_lambda, stubber_dynamodb, stubber_sqs, stubber_sns:
+        response = handler(event, {})
+
+    stubber_dynamodb.assert_no_pending_responses()
+    stubber_sns.assert_no_pending_responses()
+    stubber_sqs.assert_no_pending_responses()
+    stubber_lambda.assert_no_pending_responses()
+
+    return response
+
+
+def test_connection_record_is_retrieved(get_event):
+    event = get_event(connection_id="connection-record=")
+    run_handler(
+        event,
+        get_item_params={
+            "TableName": DYNAMODB_TABLE_NAME,
+            "Key": {"recordId": "CONN$connection-record="},
+        },
+    )
+
+
+def test_connection_record_is_deleted(get_event):
+    event = get_event(connection_id="delete-record=")
+    run_handler(
+        event,
+        delete_item_params={
+            "TableName": DYNAMODB_TABLE_NAME,
+            "Key": {"recordId": "CONN$delete-record="},
+        },
+    )
+
+
+def test_sns_subscriptions_are_deleted(get_event):
+    event = get_event()
+    run_handler(
+        event,
+        sns_subscription_arns=["subscription-one", "subscription-two"],
+        sns_params=[
+            {"SubscriptionArn": "subscription-one"},
+            {"SubscriptionArn": "subscription-two"},
+        ],
+    )
+
+
+def test_sqs_queue_is_deleted(get_event):
+    event = get_event()
+    run_handler(
+        event,
+        sqs_queue_url="https://delete-this-queue.com",
+        sqs_params={"QueueUrl": "https://delete-this-queue.com"},
+    )
+
+
+def test_lambda_event_source_mapping_is_deleted(get_event):
+    event = get_event()
+    run_handler(
+        event,
+        lambda_mapping_uuid="this-is-super-unique",
+        lambda_params={"UUID": "this-is-super-unique"},
+    )


### PR DESCRIPTION
## Purpose
Closes #14 

## Approach
Like #31, direct resource management. Lambda event source mappings take some time to recognize they're no longer needed, so I put in an exponential backoff retry.