### PR TITLE
let json handle decimal casting

### DIFF
--- a/concert/app/src/functions/aggregate_writer/index.py
+++ b/concert/app/src/functions/aggregate_writer/index.py
@@ -66,10 +66,10 @@ def create_map_for_record_if_none_exists(timestamp, choice_key):
 
 
 def add_record_to_aggregate(record):
-    data = json.loads(b64decode(record["data"]).decode("utf-8"))
+    data = json.loads(b64decode(record["data"]).decode("utf-8"), parse_float=Decimal)
     timestamp = data["CHOICE_TIME"].replace(" ", "T") + "Z"
     choice_type = data["CHOICE_TYPE"]
-    choice_sum = Decimal(data["CHOICE_SUM"])
+    choice_sum = data["CHOICE_SUM"]
     choice_count = data["CHOICE_COUNT"]
 
     update_args = {


### PR DESCRIPTION
## Purpose
Fix errors seen in CloudWatch logs for `aggregate_writer`

## Approach
These errors look to be caused by Decimal casting errors. This change stops us from doing casting ourselves by moving casting duty to the json parser.

## Testing
I've updated the code in the `aggregate_writer` function to match what's in this review (~ 2018-9-08-06:50 UTC). Consequently, errors appear to have stopped. Error count is visible on the monitoring tab of the Lambda function.

## Open Questions and Pre-Merge TODOs
<!--- Use GitHub checklists. When solved, check the box and explain the answer. -->
- [X] Have you written tests for these changes? No; unsure how to write a test for this. 
- [X] Do the docs need to be updated? No.
