### PR TITLE
Revisions

### DIFF
--- a/client/app/src/App.js
+++ b/client/app/src/App.js
@@ -14,6 +14,7 @@ import {
 } from 'aws-amplify-react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { DefaultTheme, Provider as PaperProvider } from 'react-native-paper';
+import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 
 import { persistor, store, actions } from './state';
 import SignUp from './components/SignUp';
@@ -93,9 +94,11 @@ class App extends React.Component {
     store.dispatch(actions.setUID(username));
     concertApi.on(CONNECTED, this.handleStageNavigation);
     concertApi.on(EVENT_STAGE_CHANGED, this.handleStageNavigation);
+    activateKeepAwake();
   }
 
   componentWillUnmount() {
+    deactivateKeepAwake();
     concertApi.removeListener(CONNECTED, this.handleStageNavigation);
     concertApi.removeListener(EVENT_STAGE_CHANGED, this.handleStageNavigation);
     concertApi.disconnect();

--- a/client/app/src/App.js
+++ b/client/app/src/App.js
@@ -150,6 +150,9 @@ class App extends React.Component {
     }
 
     const canConnect = !!isShowConnect || stageId === STAGE_END ? true : null;
+    if (screen === NavigationService.getState()) {
+      NavigationService.navigate('Welcome');
+    }
     NavigationService.navigate(screen, {
       choiceInverted,
       choiceType: choiceTypes.includes(choiceType) ? choiceType : choiceTypes[0],

--- a/client/app/src/App.js
+++ b/client/app/src/App.js
@@ -90,11 +90,11 @@ I18n.setLanguage(store.getState().language);
 
 class App extends React.Component {
   async componentDidMount() {
+    activateKeepAwake();
     const { 'cognito:username': username } = (await Auth.currentSession()).getIdToken().payload;
     store.dispatch(actions.setUID(username));
     concertApi.on(CONNECTED, this.handleStageNavigation);
     concertApi.on(EVENT_STAGE_CHANGED, this.handleStageNavigation);
-    activateKeepAwake();
   }
 
   componentWillUnmount() {

--- a/client/app/src/api/stub.js
+++ b/client/app/src/api/stub.js
@@ -188,7 +188,6 @@ const STAGE_DATA = {
   [STAGE_WAITING]: () => ({}),
 };
 
-
 export default stageId => {
   const { eventData, ...stageData } = STAGE_DATA[stageId]();
   return {

--- a/client/app/src/main.js
+++ b/client/app/src/main.js
@@ -1,9 +1,4 @@
 import { registerRootComponent } from 'expo';
-import { activateKeepAwake } from 'expo-keep-awake';
 import App from './App';
-
-if (__DEV__) {
-  activateKeepAwake();
-}
 
 registerRootComponent(App);

--- a/client/app/src/navigation/NavigationService.js
+++ b/client/app/src/navigation/NavigationService.js
@@ -2,6 +2,11 @@ import { NavigationActions } from 'react-navigation';
 
 let _navigator;
 
+const getState = () => {
+  const { index, routes } = _navigator.state.nav;
+  return routes[index].key;
+};
+
 const setTopLevelNavigator = navigatorRef => {
   _navigator = navigatorRef;
 };
@@ -16,6 +21,7 @@ const navigate = (routeName, params) => {
 };
 
 export default {
+  getState,
   navigate,
   setTopLevelNavigator,
 };

--- a/client/app/src/screens/Chills.js
+++ b/client/app/src/screens/Chills.js
@@ -33,8 +33,6 @@ class ChillsScreen extends Component {
       touches: [],
     };
 
-    this.interval = this.props.navigation.state.params.interval * 1000;
-
     this._panResponder = PanResponder.create({
       onStartShouldSetPanResponder: () => true,
       onMoveShouldSetPanResponder: () => true,
@@ -135,6 +133,8 @@ class ChillsScreen extends Component {
     }).start();
   };
 
+  getInterval = () => this.props.navigation.state.params.interval * 1000;
+
   registerChoice = ({ choice, timestamp }) => {
     const { nextPollTime: pollTime = timestamp, panTimeoutId, isEnded } = this.state;
     if (isEnded || timestamp < pollTime) {
@@ -146,8 +146,9 @@ class ChillsScreen extends Component {
 
     let nextPollTime = pollTime;
     const now = Date.now() + this.clockOffset;
+    const interval = this.getInterval();
     while (nextPollTime <= now) {
-      nextPollTime += this.interval;
+      nextPollTime += interval;
     }
     nextPollTime = this.roundTime(nextPollTime);
 
@@ -157,7 +158,7 @@ class ChillsScreen extends Component {
         offset: new Animated.Value(-WAVEFORM_SIZE),
         panTimeoutId: setTimeout(
           () => this.registerChoice({ choice, timestamp: nextPollTime }),
-          0.5 * this.interval + nextPollTime - (Date.now() + this.clockOffset)
+          0.5 * interval + nextPollTime - (Date.now() + this.clockOffset)
         ),
         touches: [
           ...touches,
@@ -170,12 +171,12 @@ class ChillsScreen extends Component {
       () =>
         Animated.timing(this.state.offset, {
           toValue: 0,
-          duration: this.interval,
+          duration: interval,
         }).start()
     );
   };
 
-  roundTime = time => time - (time % this.interval);
+  roundTime = time => time - (time % this.getInterval());
 
   sendTouches = touches =>
     touches

--- a/client/app/src/screens/MentalImagery.js
+++ b/client/app/src/screens/MentalImagery.js
@@ -8,15 +8,10 @@ import { COLOR_BACKGROUND_DARK } from '../constants/Colors';
 import { MESSAGE_STAGE_COMPLETE_HEADER, MESSAGE_STAGE_COMPLETE_BODY } from '../constants/Messages';
 
 export default class MentalImageryScreen extends Component {
-  constructor(props) {
-    super(props);
-
-    const { formUrl } = props.navigation.state.params;
-    this.endpoint = `${formUrl}?uid=${store.getState().uid}`;
-  }
+  getEndpoint = () => `${this.props.navigation.state.params.formUrl}?uid=${store.getState().uid}`;
 
   handleNavigationStateChange = ({ url }) => {
-    if (url === this.endpoint) {
+    if (url === this.getEndpoint()) {
       return;
     }
 
@@ -39,7 +34,7 @@ export default class MentalImageryScreen extends Component {
     return (
       <SafeAreaView style={styles.container}>
         <WebView
-          source={{ uri: this.endpoint }}
+          source={{ uri: this.getEndpoint() }}
           startInLoadingState
           renderLoading={() => loadingIndicator}
           onNavigationStateChange={this.handleNavigationStateChange}

--- a/client/app/src/screens/Results.js
+++ b/client/app/src/screens/Results.js
@@ -36,6 +36,10 @@ class ResultsScreen extends Component {
         if (!choices || !choices.length) {
           return null;
         }
+        // TEMPORARY: Don't display synesthesia results
+        if (songInfo.displayName.toLowerCase().includes('coriolan overture')) {
+          return null;
+        }
         const song = {
           startTime,
           endTime,


### PR DESCRIPTION
## Purpose
* Device screens weren't staying on
* Users weren't getting moved to the next concert stage if they got disconnected or some other error occurred while on a stage and if the next stage used the same component as the current stage.
* Chills weren't being sent if user's finger was held when the song ended

## Approach
* activateKeepAwake on app mount, deactivate on dismount
* If the next stage uses the same screen as the current, navigate away first.
* Added a separate timeout for ending synesthesia stages that doesn't rely on the prompt interval
* Don't close chills screen until results are sent